### PR TITLE
add implicit supports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requires = (
         "scikit-learn>=1.1.1",
         "matplotlib>=3.5.2",
         "plotly>=5.6.0",
+        "implicit>=0.6.0",
     ],
 )
 

--- a/src/rsdiv/recommenders/__init__.py
+++ b/src/rsdiv/recommenders/__init__.py
@@ -1,7 +1,9 @@
 from .base import BaseRecommender
 from .fm import FMRecommender
+from .ials import IALSRecommender
 
 __all__ = [
     "BaseRecommender",
     "FMRecommender",
+    "IALSRecommender",
 ]

--- a/src/rsdiv/recommenders/base.py
+++ b/src/rsdiv/recommenders/base.py
@@ -27,12 +27,13 @@ class BaseRecommender(metaclass=ABCMeta):
         item_features: Optional[pd.DataFrame] = None,
     ) -> None:
         self.df_interaction = self.get_interaction(df_interaction)
-        self.n_users, self.n_items = self.df_interaction.max()[:2]
+        self.n_users, self.n_items = self.df_interaction.max()[:2] + 1
         self.items = items
         self.user_features = user_features
         self.item_features = item_features
         self.test_size = test_size
         self.random_split = random_split
+        self.train_mat, self.test_mat = self.process_interaction()
 
     def get_interaction(self, df_interaction: pd.DataFrame) -> pd.DataFrame:
         """The converter for input dataframe
@@ -45,14 +46,12 @@ class BaseRecommender(metaclass=ABCMeta):
 
         dataframe = df_interaction.iloc[:, :3]
         dataframe.columns = pd.Index(["userId", "itemId", "interaction"])
-        dataframe["userId"] = pd.Categorical(dataframe["userId"]).codes + 1
-        dataframe["itemId"] = pd.Categorical(dataframe["itemId"]).codes + 1
+        dataframe["userId"] = pd.Categorical(dataframe["userId"]).codes
+        dataframe["itemId"] = pd.Categorical(dataframe["itemId"]).codes
         return dataframe
 
     def process_interaction(self) -> Tuple[sps.coo_matrix, sps.coo_matrix]:
         dataframe = self.df_interaction
-        print(dataframe)
-        print(self.n_users, self.n_items)
         if not (self.random_split) and self.test_size > 1:
             train = dataframe.iloc[int(self.test_size) :, :]
             test = dataframe.iloc[: int(self.test_size), :]
@@ -61,12 +60,12 @@ class BaseRecommender(metaclass=ABCMeta):
                 dataframe, test_size=self.test_size, random_state=42
             )
         train_mat = sps.coo_matrix(
-            (train.interaction, (train.userId - 1, train.itemId - 1)),
+            (train.interaction, (train.userId, train.itemId)),
             (self.n_users, self.n_items),
             "int32",
         )
         test_mat = sps.coo_matrix(
-            (test.interaction, (test.userId - 1, test.itemId - 1)),
+            (test.interaction, (test.userId, test.itemId)),
             (self.n_users, self.n_items),
             "int32",
         )
@@ -91,7 +90,7 @@ class BaseRecommender(metaclass=ABCMeta):
         raise NotImplementedError("predict must be implemented.")
 
     def predict_for_userId(self, user_id: int) -> np.ndarray:
-        user_ids: np.ndarray = np.full(self.n_items, user_id - 1)
+        user_ids: np.ndarray = np.full(self.n_items, user_id)
         item_ids: np.ndarray = np.arange(self.n_items)
         prediction = self.predict(
             user_ids, item_ids, self.user_features, self.item_features
@@ -99,9 +98,7 @@ class BaseRecommender(metaclass=ABCMeta):
         return prediction
 
     def predict_for_userId_unseen(self, user_id: int) -> np.ndarray:
-        seen = (
-            self.df_interaction[self.df_interaction["userId"] == user_id]["itemId"] - 1
-        )
+        seen = self.df_interaction[self.df_interaction["userId"] == user_id]["itemId"]
         prediction = self.predict_for_userId(user_id)
         prediction[seen] = -np.inf
         return prediction
@@ -110,7 +107,7 @@ class BaseRecommender(metaclass=ABCMeta):
         prediction = self.predict_for_userId_unseen(user_id)
         argpartition = np.argpartition(-prediction, top_n)
         result_args = argpartition[:top_n]
-        return {key + 1: prediction[key] for key in result_args}
+        return {key: prediction[key] for key in result_args}
 
     def predict_top_n_item(self, user_id: int, top_n: int) -> pd.DataFrame:
         prediction = self.predict_top_n_unseen(user_id, top_n)

--- a/src/rsdiv/recommenders/fm.py
+++ b/src/rsdiv/recommenders/fm.py
@@ -29,7 +29,6 @@ class FMRecommender(BaseRecommender):
             loss=loss,
             random_state=42,
         )
-        self.train_mat, self.test_mat = self.process_interaction()
 
     def _fit(self) -> None:
         self.fm.fit(self.train_mat, epochs=30)

--- a/src/rsdiv/recommenders/ials.py
+++ b/src/rsdiv/recommenders/ials.py
@@ -59,11 +59,9 @@ class IALSRecommender(BaseRecommender):
         user_features: Optional[sps.csr_matrix] = None,
         item_features: Optional[sps.csr_matrix] = None,
     ) -> np.ndarray:
-        ids, scores = self.recommend(user_ids)
+        user_factors = self.ials.user_factors[user_ids]
+        item_factors = self.ials.item_factors[item_ids]
         predict_array: np.ndarray = np.asarray(
-            [
-                score[user.index(item)]
-                for user, item, score in zip(ids, item_ids, scores)
-            ]
+            [user @ item for user, item in zip(user_factors, item_factors)]
         )
         return predict_array

--- a/src/rsdiv/recommenders/ials.py
+++ b/src/rsdiv/recommenders/ials.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 from implicit.als import AlternatingLeastSquares
 from scipy import sparse as sps
+from sklearn.metrics import roc_auc_score
 
 from .base import BaseRecommender
 
@@ -51,6 +52,13 @@ class IALSRecommender(BaseRecommender):
         )
         id_list: List = [list(id) for id in ids]
         return (id_list, scores)
+
+    def auc_score(self) -> float:
+        test: pd.DataFrame = self.df_interaction.head(self.test_size)
+        user_ids: np.ndarray = test["userId"]
+        item_ids: np.ndarray = test["itemId"]
+        prediction: np.ndarray = self.predict(user_ids, item_ids)
+        return float(roc_auc_score(test["interaction"], prediction))
 
     def predict(
         self,

--- a/src/rsdiv/recommenders/ials.py
+++ b/src/rsdiv/recommenders/ials.py
@@ -1,0 +1,66 @@
+from typing import List, Optional, Union
+
+import numpy as np
+import pandas as pd
+from implicit.als import AlternatingLeastSquares
+from scipy import sparse as sps
+
+from .base import BaseRecommender
+
+
+class IALSRecommender(BaseRecommender):
+    def __init__(
+        self,
+        df_interaction: pd.DataFrame,
+        items: pd.DataFrame,
+        test_size: Union[float, int],
+        random_split: bool = False,
+        factors: int = 64,
+        regularization: float = 0.05,
+    ) -> None:
+        super().__init__(df_interaction, items, test_size, random_split)
+        self.ials = AlternatingLeastSquares(
+            factors=factors, regularization=regularization
+        )
+        self.train_mat = self.bm25(self.train_mat)
+
+    def bm25(self, X: sps.coo_matrix, K1: int = 100, B: float = 0.8) -> sps.csr_matrix:
+        """Weighs each col of a sparse matrix X  by BM25 weighting.
+        - `Taken from nearest_neighbours.py of implicit
+          <https://github.com/benfred/implicit/blob/main/implicit/nearest_neighbours.py>`_
+        """
+
+        X = X.T
+        N = float(X.shape[0])
+        idf = np.log(N) - np.log1p(np.bincount(X.col))
+        row_sums = np.ravel(X.sum(axis=1))
+        average_length = row_sums.mean()
+        length_norm = (1.0 - B) + B * row_sums / average_length
+        X.data = X.data * (K1 + 1.0) / (K1 * length_norm[X.row] + X.data) * idf[X.col]
+        return X.T.tocsr()
+
+    def _fit(self) -> None:
+        self.ials.fit(2 * self.train_mat)
+
+    def recommend(self, user_ids: np.ndarray) -> tuple:
+        ids, scores = self.ials.recommend(
+            user_ids, self.train_mat[user_ids], N=self.n_items
+        )
+        id_list: List = [list(id) for id in ids]
+        return (id_list, scores)
+
+    def predict(
+        self,
+        user_ids: np.ndarray,
+        item_ids: np.ndarray,
+        user_features: Optional[sps.csr_matrix] = None,
+        item_features: Optional[sps.csr_matrix] = None,
+    ) -> np.ndarray:
+        ids, scores = self.recommend(user_ids)
+        predict_array: np.ndarray = np.asarray(
+            [
+                score[user.index(item)]
+                for user, item, score in zip(ids, item_ids, scores)
+            ]
+        )
+        return predict_array

--- a/src/rsdiv/recommenders/ials.py
+++ b/src/rsdiv/recommenders/ials.py
@@ -17,10 +17,13 @@ class IALSRecommender(BaseRecommender):
         random_split: bool = False,
         factors: int = 64,
         regularization: float = 0.05,
+        random_state: Optional[int] = 42,
     ) -> None:
         super().__init__(df_interaction, items, test_size, random_split)
         self.ials = AlternatingLeastSquares(
-            factors=factors, regularization=regularization
+            factors=factors,
+            regularization=regularization,
+            random_state=random_state,
         )
         self.train_mat = self.bm25(self.train_mat)
 


### PR DESCRIPTION
- add basic supports for `IALSRecommender`
- change the start index from `1` to `0` for the base recommenders
- move the preprocessing phase back to the base class of recommenders